### PR TITLE
Updated image from app/$NAME to dokku/$NAME

### DIFF
--- a/pre-build
+++ b/pre-build
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-APP="$1"; IMAGE="app/$APP"
+APP="$1"; IMAGE="dokku/$APP"
 SOURCE_ENV_PATH="$HOME/$APP/ENV"
 
 if [[ -f "$SOURCE_ENV_PATH" ]]; then


### PR DESCRIPTION
I have dokku 0.2.3, and my images are named `dokku/*`. This seems strange, since it was changed from `dokku/*` to `app/*` _after_ forking it from musicglue's repo. Can somebody else confirm this is indeed correct?
