### PR TITLE
Removed unneeded plugin installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,4 @@ dokku-user-env-compile is to dokku what [user-env-compile](https://devcenter.her
 ```sh
 cd /var/lib/dokku/plugins
 git clone https://github.com/motin/dokku-user-env-compile.git user-env-compile
-dokku plugins-install
 ```


### PR DESCRIPTION
`dokku plugins-install` runs the install script, but there isn't one so this isn't needed.
